### PR TITLE
STOX-747: Parameter Resizable table header

### DIFF
--- a/frontend/src/app/parameter/parameter.component.html
+++ b/frontend/src/app/parameter/parameter.component.html
@@ -8,14 +8,20 @@
             <col *ngFor="let col of columns" [style.width]="col.width" />
           </colgroup>
         </ng-template>
+        <ng-template pTemplate="header">
+          <tr>
+            <th pResizableColumn style="height: 2px"></th>
+            <th pResizableColumn style="height: 2px"></th>
+          </tr>
+        </ng-template>
         <ng-template pTemplate="body" let-propertyItem>
-          <tr style="white-space: nowrap">
-            <td pResizableColumn>
+          <tr>
+            <td>
               <div class="ellipsiscolumn">
                 {{ propertyItem.displayName }}
               </div>
             </td>
-            <td pResizableColumn [ngSwitch]="propertyItem.type">
+            <td [ngSwitch]="propertyItem.type">
               <!-- character -->
               <div *ngSwitchCase="'character'">
                 <!-- If possible values are given but not vector, do autocomlpetion -->

--- a/frontend/src/app/parameter/parameter.component.ts
+++ b/frontend/src/app/parameter/parameter.component.ts
@@ -21,8 +21,8 @@ import { ExpressionBuilderDlgService } from './../expressionBuilder/ExpressionBu
 })
 export class ParameterComponent {
   cols = [
-    { field: 'name', header: 'Name', width: '50%' },
-    { field: 'value', header: 'Value', width: '50%' },
+    { field: 'name', header: 'Name' },
+    { field: 'value', header: 'Value' },
   ];
 
   constructor(


### PR DESCRIPTION
Resize virker bare på header-raden ifølge dokumentasjonen.
Har lagt inn en tom header rad nå, så den ikke blir unødvendig stor.

@arnejohannesholmin kan se om det er OK.

I tillegg ved å fjerne 50% width, vil de være mer dynamisk bredde. Og verdi-kolonnen får automatisk mer plass ved resizing.